### PR TITLE
Add ecl code security

### DIFF
--- a/aks/variables.tf
+++ b/aks/variables.tf
@@ -1,10 +1,3 @@
-variable "availability_zones" {
-  description = "Availability zones to use for the node groups."
-  type        = list(number)
-  nullable    = false
-  default     = [1]
-}
-
 variable "tags" {
   description = "Tags to apply to all resources."
   type        = map(string)

--- a/hpcc/hpcc.tf
+++ b/hpcc/hpcc.tf
@@ -41,6 +41,8 @@ module "hpcc" {
     username = local.hpcc_container_registry_auth.username
   } : null
 
+  storage_data_gb = var.storage_data_gb
+
   install_blob_csi_driver = false //Disable CSI driver
 
   resource_group_name = local.get_aks_config.resource_group_name
@@ -114,5 +116,6 @@ module "hpcc" {
   helm_chart_files_overrides = concat(local.helm_chart_files_overrides, fileexists("../logging/data/logaccess_body.yaml") ? ["../logging/data/logaccess_body.yaml"] : [])
   ldap_config                = local.ldap_config
 
+  enable_code_security       = var.enable_code_security
   authn_htpasswd_filename    = var.authn_htpasswd_filename
 }

--- a/hpcc/hpcc.tf
+++ b/hpcc/hpcc.tf
@@ -19,8 +19,8 @@ resource "kubernetes_namespace" "hpcc" {
 }*/
 
 module "hpcc" {
-  source = "git@github.com:gfortil/opinionated-terraform-azurerm-hpcc?ref=HPCC-27615"
-  #source = "/home/azureuser/temp/opinionated-terraform-azurerm-hpcc"
+  #source = "git@github.com:gfortil/opinionated-terraform-azurerm-hpcc?ref=HPCC-27615"
+  source = "/home/azureuser/temp/opinionated-terraform-azurerm-hpcc"
 
   environment = local.metadata.environment
   productname = local.metadata.product_name

--- a/hpcc/hpcc.tf
+++ b/hpcc/hpcc.tf
@@ -19,8 +19,9 @@ resource "kubernetes_namespace" "hpcc" {
 }*/
 
 module "hpcc" {
-  #source = "git@github.com:gfortil/opinionated-terraform-azurerm-hpcc?ref=HPCC-27615"
-  source = "/home/azureuser/temp/opinionated-terraform-azurerm-hpcc"
+  source = "git@github.com:gfortil/opinionated-terraform-azurerm-hpcc?ref=HPCC-27615"
+  #source = "/home/azureuser/temp/opinionated-terraform-azurerm-hpcc"
+  #source = "/home/azureuser/tlhumphrey2/RBA-terraform-azurerm-hpcc"
 
   environment = local.metadata.environment
   productname = local.metadata.product_name

--- a/hpcc/hpcc.tf
+++ b/hpcc/hpcc.tf
@@ -86,6 +86,7 @@ module "hpcc" {
   external_storage_config = local.external_storage_config
 
   spill_volumes                = local.spill_volumes
+  enable_roxie                 = var.enable_roxie
   roxie_config                 = local.roxie_config
   thor_config                  = local.thor_config
   vault_config                 = local.vault_config

--- a/hpcc/hpcc.tf
+++ b/hpcc/hpcc.tf
@@ -113,4 +113,6 @@ module "hpcc" {
   helm_chart_timeout         = local.helm_chart_timeout
   helm_chart_files_overrides = concat(local.helm_chart_files_overrides, fileexists("../logging/data/logaccess_body.yaml") ? ["../logging/data/logaccess_body.yaml"] : [])
   ldap_config                = local.ldap_config
+
+  authn_htpasswd_filename    = var.authn_htpasswd_filename
 }

--- a/hpcc/lite-locals.tf
+++ b/hpcc/lite-locals.tf
@@ -161,6 +161,17 @@ locals {
   #   }
   # }
 
+  roxie_internal_service = {
+    name        = "iroxie"
+    servicePort = 9876
+    listenQueue = 200
+    numThreads  = 30
+    visibility  = "local"
+    annotations = {}
+  }
+
+  roxie_services = [local.roxie_internal_service]
+
   #========================================
   # defaults in godji original variables.tf
   expose_services = false
@@ -315,16 +326,7 @@ locals {
       useMemoryMappedIndexes         = false
       useRemoteResources             = false
       useTreeCopy                    = false
-      services = [
-        {
-          name        = "roxie"
-          servicePort = 9876
-          listenQueue = 200
-          numThreads  = 30
-          visibility  = "local"
-          annotations = {}
-        }
-      ]
+      services                       = local.roxie_services
       topoServer = {
         replicas = 1
       }

--- a/hpcc/lite-locals.tf
+++ b/hpcc/lite-locals.tf
@@ -472,7 +472,7 @@ locals {
   admin_services_node_selector = {}
 
   thor_config = [{
-    disabled            = ((var.thor_num_workers == 0 ) || (var.thor_num_workers == null))? true : false
+    disabled            = (var.enable_thor == true) || (var.enable_thor == null)? false : true
     name                = "thor"
     prefix              = "thor"
     numWorkers          = var.thor_num_workers

--- a/hpcc/lite-variables.tf
+++ b/hpcc/lite-variables.tf
@@ -2,6 +2,11 @@
 # Prompted variables (user will be asked to supply them at plan/apply time
 # if a .tfvars file is not supplied); there are no default values
 ###############################################################################
+variable "enable_thor" {
+  description = "REQUIRED.  If you want a thor cluster."
+  type        = bool
+}
+
 
 variable "a_record_name" {
   type        = string

--- a/hpcc/lite-variables.tf
+++ b/hpcc/lite-variables.tf
@@ -69,11 +69,6 @@ variable "enable_code_security" {
   type        = bool
 }
 
-variable "enable_rbac_ad" {
-  description = "REQUIRED.  Enable RBAC and AD integration for AKS?\nThis provides additional security for accessing the Kubernetes cluster and settings (not HPCC Systems' settings).\nValue type: boolean\nRecommended value: true\nExample entry: true"
-  type        = bool
-}
-
 variable "enable_roxie" {
   description = "REQUIRED.  Enable ROXIE?\nThis will also expose port 8002 on the cluster.\nExample entry: false"
   type        = bool

--- a/hpcc/lite.auto.tfvars.example
+++ b/hpcc/lite.auto.tfvars.example
@@ -55,16 +55,6 @@ enable_roxie=false
 
 #------------------------------------------------------------------------------
 
-# Enable RBAC and AD integration for AKS?
-# This provides additional security for accessing the Kubernetes cluster and settings (not HPCC Systems' settings).
-# Value type: boolean
-# Recommended value: true
-# Example entry: true
-
-enable_rbac_ad=false
-
-#------------------------------------------------------------------------------
-
 # Enable code security?
 # If true, only signed ECL code will be allowed to create embedded language functions, use PIPE(), etc.
 # Value type: boolean

--- a/hpcc/lite.auto.tfvars.example
+++ b/hpcc/lite.auto.tfvars.example
@@ -74,6 +74,13 @@ enable_code_security=true
 
 #------------------------------------------------------------------------------
 
+# If you want a thor cluster then 'enable_thor' must be set to true
+# Otherwise it is set to false
+
+enable_thor=true
+
+#------------------------------------------------------------------------------
+
 # The number of Thor workers to allocate.
 # Must be 1 or more.
 

--- a/hpcc/main.tf
+++ b/hpcc/main.tf
@@ -30,11 +30,11 @@ module "metadata" {
   project             = local.metadata.project
 }
 
-resource "null_resource" "launch_svc_url" {
+/*resource "null_resource" "launch_svc_url" {
   for_each = (module.hpcc.hpcc_status == "deployed") && (local.auto_launch_svc.eclwatch == true) ? local.svc_domains : {}
 
   provisioner "local-exec" {
     command     = local.is_windows_os ? "Start-Process ${each.value}" : "open ${each.value} || xdg-open ${each.value}"
     interpreter = local.is_windows_os ? ["PowerShell", "-Command"] : ["/bin/bash", "-c"]
   }
-}
+}*/


### PR DESCRIPTION
1. Added 'internal_storage_enabled'. It is used to set local.external_storage_config_enabled.
2. Added support for htpasswd (most of the changes are in local.tf).
3. Added support for signing security of ecl code (most of the changes are in local.tf).
4. In local.tf, use 'var.storage_data_gb' to set the Pi size of internal data storage.
5. In local.tf, setup eclqueries service to be globally visable with port 18002 WHEN roxie is enabled.