### PR TITLE
branch:aks-is-now-using-easy-deploy-variables

### DIFF
--- a/aks/aks.tf
+++ b/aks/aks.tf
@@ -21,8 +21,9 @@
 module "aks" {
   depends_on = [random_string.string]
   #source     = "github.com/gfortil/terraform-azurerm-aks.git?ref=HPCC-27615"
-  source     = "git@github.com:gfortil/terraform-azurerm-aks.git?ref=HPCC-27615"
+  #source     = "git@github.com:gfortil/terraform-azurerm-aks.git?ref=HPCC-27615"
   #source     = "/home/azureuser/temp/terraform-azurerm-aks"
+  source     = "/home/azureuser/tlhumphrey2/rba-rsg-terraform-azurerm-aks"
 
   providers = {
     kubernetes = kubernetes.default
@@ -63,7 +64,7 @@ module "aks" {
 
     ingress_internal_core = {
       domain           = local.core_services_config.ingress_internal_core.domain
-      subdomain_suffix = "${local.core_services_config.ingress_internal_core.subdomain_suffix}${trimspace(local.owner.name)}" // dns record suffix
+      subdomain_suffix = "${local.core_services_config.ingress_internal_core.subdomain_suffix}${trimspace(local.owner_name_initials)}" // dns record suffix
       public_dns       = local.core_services_config.ingress_internal_core.public_dns
     }
   }
@@ -75,10 +76,13 @@ module "aks" {
     blob = { enabled = true }
   }
 
-  logging = var.logging
+  # tlh logging = var.logging
+  logging = null
 
   experimental = {
     oms_agent                            = var.hpcc_log_analytics_enabled || var.experimental.oms_agent
     oms_agent_log_analytics_workspace_id = fileexists("../logging/data/workspace_resource_id.txt") ? file("../logging/data/workspace_resource_id.txt") : var.experimental.oms_agent_log_analytics_workspace_id != null ? var.experimental.oms_agent_log_analytics_workspace_id : null
+    #tlh tried this oms_agent                            = null
+    #tlh tried this oms_agent_log_analytics_workspace_id = null
   }
 }

--- a/aks/lite-locals.tf
+++ b/aks/lite-locals.tf
@@ -8,6 +8,8 @@ locals {
     email = var.aks_admin_email
   }
 
+  owner_name_initials = lower(join("",[for x in split(" ",local.owner.name): substr(x,0,1)]))
+
   metadata = {
     project             = "tlhhpccplatform"
     product_name        = "tlhhpccplatform"

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,4 +1,5 @@
 #!/bin/bash
+repodir=`dirname `pwd`/deploy|sed "s/\/scripts\/*//"`
 if [ "$1" != "" ];then
   name=$1
 else
@@ -83,4 +84,5 @@ echo "=============== Deploy $name. Executing 'terraform plan -out=$plan' ======
 assert_fail terraform plan -out=$plan
 echo "=============== Deploy $name. Executing 'terraform apply $plan'  ===============";
 assert_fail terraform apply $plan
+cd $repodir
 rm *.tfstate*;rm .terraform.lock.hcl ;sudo rm -r .terraform


### PR DESCRIPTION
Added 'cd $repodir' to scripts/deploy.
In aks, created initials from owner.name and then used those initials in aks.tf to create 'subdomain_suffix'.