### PR TITLE
branch:HPCC-27615-easy-deploy-bryan9-variable-eclwatch-a-record

### DIFF
--- a/hpcc/hpcc.tf
+++ b/hpcc/hpcc.tf
@@ -21,12 +21,13 @@ resource "kubernetes_namespace" "hpcc" {
 module "hpcc" {
   #source = "git@github.com:gfortil/opinionated-terraform-azurerm-hpcc?ref=HPCC-27615"
   #source = "/home/azureuser/temp/opinionated-terraform-azurerm-hpcc"
-  #source = "/home/azureuser/tlhumphrey2/RBA-terraform-azurerm-hpcc"
-  source = "git@github.com:hpccsystems-solutions-lab/tlh-opinionated-terraform-azurerm-hpcc.git?ref=add-ecl-code-security-misc"
+  source = "/home/azureuser/tlhumphrey2/RBA-terraform-azurerm-hpcc"
+  #source = "git@github.com:hpccsystems-solutions-lab/tlh-opinionated-terraform-azurerm-hpcc.git?ref=add-ecl-code-security-misc"
 
   environment = local.metadata.environment
   productname = local.metadata.product_name
 
+  a_record_name   = var.a_record_name
   internal_domain = local.internal_domain
   #cluster_name    = local.get_aks_config.cluster_name
   cluster_name    = jsondecode(file("../aks/data/config.json")).cluster_name

--- a/hpcc/outputs.tf
+++ b/hpcc/outputs.tf
@@ -1,6 +1,6 @@
 output "eclwatch_url" {
   description = "Print the ECL Watch URL."
-  value       = format("eclwatch-default.%s:18010",var.aks_dns_zone_name)
+  value       = format("%s.%s:18010",var.a_record_name, var.aks_dns_zone_name)
 }
 
 output "deployment_resource_group" {

--- a/lite-variables.tf
+++ b/lite-variables.tf
@@ -27,8 +27,8 @@ variable "enable_thor" {
 
 variable "a_record_name" {
   type        = string
-  description = "OPTIONAL: dns zone A record name"
-  default     = ""
+  description = "REQUIRED: dns zone A record name for eclwatch"
+  default     = "eclwatch-default"
 }
 
 variable "aks_admin_email" {


### PR DESCRIPTION
Now you can change the eclwatch A record. It was hard coded as eclwatch-default.