### PR TITLE
branch:main-review-mods-2023-11-17-activate-aks_node_size. aks_node_s…

### DIFF
--- a/lite.auto.tfvars.example
+++ b/lite.auto.tfvars.example
@@ -105,7 +105,7 @@ extra_tags={}
 # See https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-general for more information.
 # Value type: string
 
-aks_node_size="Standard_B8ms"
+aks_node_size="Standard_D4s_v4"
 
 #------------------------------------------------------------------------------
 


### PR DESCRIPTION
…ize=Standard_D4s_v4. Set aks_node_size="Standard_D4s_v4" because ecl programs wouldn't run on hpcc with other size.